### PR TITLE
"draft" feature-database-redesign

### DIFF
--- a/server/messenger_backend/models/conversation.py
+++ b/server/messenger_backend/models/conversation.py
@@ -1,30 +1,9 @@
 from django.db import models
 from django.db.models import Q
-
 from . import utils
-from .user import User
 
 
 class Conversation(utils.CustomModel):
 
-    user1 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user1Id", related_name="+"
-    )
-    user2 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user2Id", related_name="+", 
-    )
     createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
     updatedAt = models.DateTimeField(auto_now=True)
-
-    # find conversation given two user Ids
-    def find_conversation(user1Id, user2Id):
-        # return conversation or None if it doesn't exist
-        try:
-            return Conversation.objects.get(
-                (Q(user1__id=user1Id) | Q(user1__id=user2Id)),
-                (Q(user2__id=user1Id) | Q(user2__id=user2Id)),
-            )
-        except Conversation.DoesNotExist:
-            return None
-
-        

--- a/server/messenger_backend/models/conversation_user.py
+++ b/server/messenger_backend/models/conversation_user.py
@@ -1,0 +1,20 @@
+from django.db import models
+from django.db.models import Q
+from . import utils
+from .user import User
+from .conversation import Conversation
+
+
+class ConversationUser(utils.CustomModel):
+
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, db_column="userId", related_name="+"
+    )
+    conversation = models.ForeignKey(
+        Conversation,
+        on_delete=models.CASCADE,
+        db_column="conversationId",
+        related_name="conversation_users",
+        related_query_name="conversation_user",
+    )
+    addedAt = models.DateTimeField(auto_now_add=True)

--- a/server/messenger_backend/models/message.py
+++ b/server/messenger_backend/models/message.py
@@ -1,5 +1,5 @@
 from django.db import models
-
+from django.contrib.postgres.fields import ArrayField
 from . import utils
 from .conversation import Conversation
 
@@ -12,8 +12,13 @@ class Message(utils.CustomModel):
         on_delete=models.CASCADE,
         db_column="conversationId",
         related_name="messages",
-        related_query_name="message"
+        related_query_name="message",
     )
     createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
     updatedAt = models.DateTimeField(auto_now=True)
     readAt = models.DateTimeField(null=True)
+    readBy = (
+        ArrayField(
+            models.CharField(blank=True),
+        ),
+    )


### PR DESCRIPTION
close #3 

**What additional changes are needed to implement this feature (we want this to be high level but thorough)?**

    How we GET and PUT our conversations, and POST our messages would have to be changed because currently these operations rely on the two user model. For example, we would have to find our conversations by seeing if a list of users (can be 1 to many) are participants in a conversation or by simply looking up the conversation with a conversation ID. Otheruser would have to be changed to otherUsers which would be a list of users attached to that conversation. To get a list of users for a certain conversation we would have to use the new table conversation_user (ex. convo.conversation_user) and make a list from the values returned from its Django model.
    How read messages are displayed (client side) would have to be changed. For this change we would have to add functionality to show one to many avatars under a message depending on whether it is read by one to many users. A mapping of all the users that read the message to a component called ReadBy should help. This component would have Material UI’s avatar badge inside a Material UI grid.
    The sidebar (client side) would have to show more users per conversation. We would add a Material UI grid in each conversation space that condenses as more users are added to the conversation. If there is only one user it would look like how it is currently.
    To show a conversation as an optional social group feature, a  "add to conversation"  or “start a new conversation” prompt would have to be implemented. This could be implemented with the search for users that we currently have now (in the sidebar) by the user clicking on a user and the prompt appearing (inside the currently clicked on user box located in the sidebar) asking if they want the user (currently clicked on) to be a part of a current conversation or to start a new conversation with the user (currently clicked on).
    The top area for conversations would have to show one to many user names depending on the number of users in the active conversation. A material UI grid with the usernames currently in the conversation would help.
    We would have to change how messages are sent and received through socket.io because there is a possibility now that it won't be just one user receiving a message but many users. Therefore the message being emitted would be sent to multiple clients.


**If our app were already deployed, what steps would we need to take to move to this new feature without disrupting service for current users?**

    Create unit tests for every possible situation. For example, seeing if the old structure (two users per conversation) data can be transferred correctly to our new structure (more than two users per conversation). To transfer data from the old structure to our new structure would be a timely task. Let's say we have a massive data collection of conversations. Our new database schema requires that we remove the user1 and user2 field from our conversation table. But we simply can’t do that because that would corrupt our current users data. We would have to first transfer our user1 and user2 fields data over to our new conversation_user table user field with their corresponding conversation_id. Without writing a program to do this for us, this task would take a lot of unnecessary time.
    User testing is essential for making sure a new feature works properly before deploying it into our main branch. For example, we let a certain amount of users use the new feature for a certain amount of time in a separate branch while closely monitoring these user's feedback and actions to weed out potential or present bugs (open testing, closed testing, internal testing).
    Once it passes testing we would maybe have to shut down the app for a certain amount of time to merge the new feature branch to the main branch or activate the feature with feature flags. Also we would have to notify the users that a patch is being implemented ahead of time while being as informative as possible. This includes creating patch notes that let the users know what changes to expect, giving users an amount of time the application may be down for and letting users know when the new changes will be in effect.

![messenger-2874 drawio](https://user-images.githubusercontent.com/81199750/141698272-3e400c31-f7ca-4cc1-a1af-1e5beb307df7.png)